### PR TITLE
rename kube-storage to csi-addons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 The kube-storage Authors. All rights reserved.
+# Copyright 2021 The csi-addons Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
as the org name is changed from kube-storage to csi-addons. renaming the same.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>