### PR TITLE
Add Mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,68 @@
+---
+defaults:
+  actions:
+    queue:
+      name: default
+      method: rebase
+      rebase_fallback: merge
+      update_method: rebase
+
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=test-lint
+      - check-success=test-protoc
+
+pull_request_rules:
+  - name: remove outdated approvals
+    conditions:
+      - base~=^(main)|(release-.+)$
+    actions:
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
+
+  - name: merge after one approval (no design changes)
+    conditions:
+      - base~=^(main)|(release-.+)$
+      - label!=design
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - check-success=test-lint
+      - check-success=test-protoc
+    actions:
+      queue: {}
+      dismiss_reviews: {}
+      delete_head_branch: {}
+
+  - name: design changes needs approval from at least one core maintainer
+    conditions:
+      - base~=^(main)|(release-.+)$
+      - label=design
+      - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
+      - "approved-reviews-by=@csi-addons/maintainers"
+      - check-success=test-lint
+      - check-success=test-protoc
+    actions:
+      queue: {}
+      dismiss_reviews: {}
+      delete_head_branch: {}
+
+  - name: label design changes (update the generated Go files)
+    conditions:
+      - files~=^(lib/go/)
+    actions:
+      label:
+        add:
+          - design
+
+  - name: request reviews from reviewers for design changes
+    conditions:
+      - files~=(lib/go/)$
+      - -closed
+      - -draft
+    actions:
+      request_reviews:
+        users_from_teams:
+          - "@csi-addons/maintainers"

--- a/.github/workflows/protoc.yaml
+++ b/.github/workflows/protoc.yaml
@@ -13,5 +13,5 @@ jobs:
 
     - name: generate go libs using protoc
       run: |
-        make build
+        make
         make check-changes


### PR DESCRIPTION
This configuration adds a `design` label to any change that updates
files under `lib/go/`. Changes to designs are required to re-generate
the API, and should trigger adding the `design` label.

When the `deisgn` label is set, at least two approvals are required. For
other changes, a single approval is sufficient.

This also corrects the test-protoc workflow as it should run 'make' instead of 'make build'.

By runnnig 'make' (which is 'make all'), the files under lib/go get
updated as well. The 'make check-changes' that is part of the procol
workflow will then fail in case changes are not part of the PR.

Fixes: #3 #34