### PR TITLE
ci: "make check-changes" should return non-zero exit status on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 all:
 
 check-changes:
-	output=`git status -z *.go | tr '\0' '\n'`; if test -z "$$output"; then echo "all good"; else echo "files got changed" exit 1; fi
+	output=`git status -z *.go | tr '\0' '\n'`; if test -z "$$output"; then echo "all good"; else echo "files got changed" ; exit 1; fi
 
 clean-deps:
 	rm -rf bin dist github.com google


### PR DESCRIPTION
The check does detect changed files, but echos "exit 1" instead of
executing it. A missing `;` is the cause of that, adding it makes the
test successfully fail.