### PR TITLE
ci: update super linter to v4

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Lint Code Base
-      uses: github/super-linter@v3
+      uses: github/super-linter@v4
       env:
         LINTER_RULES_PATH: extras
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -18,4 +18,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # disabling go test as its auto generated code
         VALIDATE_GO: false
+        # disabling linting process of the natural language
+        VALIDATE_NATURAL_LANGUAGE: false
         MARKDOWN_CONFIG_FILE: .markdownlint.json


### PR DESCRIPTION
updating super linter to v4 to avoid hitting https://github.com/github/super-linter/issues/2253

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>