### PR TITLE
ci: remove deprecated `rebase_fallback` from Mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,6 @@ defaults:
     queue:
       name: default
       method: rebase
-      rebase_fallback: merge
       update_method: rebase
 
 queue_rules:


### PR DESCRIPTION
Removes the deprecated `rebase_fallback` option from the Mergify configuration.

See-also: https://docs.mergify.com/actions/merge/#options