### PR TITLE
ci: remove `GITHUB_TOKEN` from linter workflow

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -7,15 +7,15 @@ on:
 jobs:
   test-lint:
     runs-on: ubuntu-latest
+
     steps:
     - name: checkout source
       uses: actions/checkout@v2
 
     - name: Lint Code Base
-      uses: github/super-linter@v4
+      uses: github/super-linter@v5
       env:
         LINTER_RULES_PATH: extras
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # disabling go test as its auto generated code
         VALIDATE_GO: false
         # disabling linting process of the natural language


### PR DESCRIPTION
Linter logs contain lots of errors like these:

    [INFO]   ERROR! Failed to call GitHub Status API!
    [INFO]   ERROR:[curl: (22) The requested URL returned error: 403]

By removing the `GITHUB_TOKEN`, no unknown status updates will be set, so the errors are gone.