### PR TITLE
ci: add dependabot configuration to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - testing


### PR DESCRIPTION
Actions that are used for GitHub Workflows can be automatically updated in most occasions. Dependabot is offered to help with this.