### PR TITLE
Use CSI Spec 1.8.0

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -22,7 +22,7 @@ PROTOC_FOUND := $(shell ../bin/protoc --version 2> /dev/null)
 PROTOC_GEN_GO_FOUND := $(shell ../bin/protoc-gen-go --version 2>&1 | grep protoc-gen-go)
 PROTOC_GEN_GO_GRPC_FOUND := $(shell ../bin/protoc-gen-go-grpc --version 2> /dev/null)
 
-CSI_SPEC_VERSION := v1.5.0
+CSI_SPEC_VERSION := v1.8.0
 
 ifeq ("${PROTOC_FOUND}","libprotoc ${PROTOC_VERSION}")
 	HAVE_PROTOC = "yes"


### PR DESCRIPTION
Version 1.5 from the CSI Spec has been released 2 years ago, 1.8.0 is only a few months old and includes more message types that can be re-used with new features like VolumeGroup.