### PR TITLE
volumegroup: the `CREATE_DELETE_VOLUME_GROUP` does not exist

### DIFF
--- a/volumegroup/README.md
+++ b/volumegroup/README.md
@@ -40,7 +40,7 @@ service Controller {
 
 #### `CreateVolumeGroup`
 
-A Controller Plugin MUST implement this RPC call if it has `CREATE_DELETE_VOLUME_GROUP` controller capability.
+A Controller Plugin MUST implement this RPC call if it has `VOLUME_GROUP` controller capability.
 
 This RPC will be called by the CO to create a new volume group on behalf of a user. This operation MUST be idempotent.
 If a volume group corresponding to the specified volume group name already exists, is compatible with the specified
@@ -124,7 +124,7 @@ CO MUST implement the specified error recovery behavior when it encounters the g
 
 #### `DeleteVolumeGroup`
 
-A Controller Plugin MUST implement this RPC call if it has `CREATE_DELETE_VOLUME_GROUP` capability.
+A Controller Plugin MUST implement this RPC call if it has `VOLUME_GROUP` capability.
 
 This RPC will be called by the CO to delete a volume group on behalf of a user. This operation MUST be idempotent.
 


### PR DESCRIPTION
The `CreateVolumeGroup` procedure refers to the
`CREATE_DELETE_VOLUME_GROUP` capability, but that does not seem to
exist. Instead, use the `VOLUME_GROUP` capability to indicate that the
plugin supports the `CreateVolumeGroup` and `DeleteVolumeGroup`
procedures.